### PR TITLE
Make the error page text more generic

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ IMAGE := cloud-platform-custom-error-pages:0.2
 
 all: .built-image
 
-.built-image:
+.built-image: rootfs/www/*
 	docker build -t $(IMAGE) .
 	touch .built-image
 

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := cloud-platform-custom-error-pages:0.2
+IMAGE := cloud-platform-custom-error-pages:0.3
 
 all: .built-image
 

--- a/rootfs/www/4xx.html
+++ b/rootfs/www/4xx.html
@@ -39,8 +39,7 @@
           <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
           <p class="govuk-body">Try again later.</p>
           <p class="govuk-body">
-            We have not saved your answers. When the service is available, you
-            will have to start again.
+            Any answers you provided may not have been saved. When the service is available, you might have to start again.
           </p>
         </div>
       </div>

--- a/rootfs/www/5xx.html
+++ b/rootfs/www/5xx.html
@@ -39,8 +39,7 @@
           <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
           <p class="govuk-body">Try again later.</p>
           <p class="govuk-body">
-            We have not saved your answers. When the service is available, you
-            will have to start again.
+            Any answers you provided may not have been saved. When the service is available, you might have to start again.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Also, alter the build dependencies, so that changes to the error pages cause
the image to be rebuilt.