### PR TITLE
Replace broken stylesheet links with embedded css

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := cloud-platform-custom-error-pages:0.3
+IMAGE := cloud-platform-custom-error-pages:0.4
 
 all: .built-image
 

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ all: .built-image
 	docker build -t $(IMAGE) .
 	touch .built-image
 
-push:
+push: .built-image
 	docker tag $(IMAGE) ministryofjustice/$(IMAGE)
 	docker push ministryofjustice/$(IMAGE)
 

--- a/rootfs/www/4xx.html
+++ b/rootfs/www/4xx.html
@@ -7,12 +7,50 @@
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <!--[if !IE 8]><!-->
-      <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-12834c68c68ece6f048a225d82a7cb85.css">
-      <!--<![endif]-->
-      <!--[if IE 8]>
-        <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-ie8-d972b1b89dd1d4ce4766d283792aa800.css">
-      <![endif]-->
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        color: #0b0c0c;
+        margin: 20px 10%;
+      }
+
+      .govuk-header__container {
+        position: relative;
+        margin-bottom: -15px;
+        padding-top: 10px;
+        border-bottom: 10px solid #1d70b8;
+      }
+
+      .govuk-header {
+        background-color: black;
+        padding: 5px 10px;
+        margin-bottom: 50px;
+      }
+      .govuk-header a {
+        color: white;
+        text-decoration: none;
+        font-size: 30px;
+      }
+
+      .govuk-header__logotype {
+      }
+
+
+      .govuk-grid-row {
+        margin-bottom: 100px;
+      }
+
+      hr {
+        margin-top: 50px;
+        margin-bottom: 50px;
+      }
+
+      .govuk-footer
+        .govuk-footer__link {
+        color: #0b0c0c;
+      }
+
+    </style>
   </head>
   <body class="govuk-template__body ">
     <header class="fb-block fb-block-header govuk-header" role="banner" data-module="header" data-block-id="config.header" data-block-type="header">

--- a/rootfs/www/4xx.html
+++ b/rootfs/www/4xx.html
@@ -9,10 +9,10 @@
 
     <!--[if !IE 8]><!-->
       <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-12834c68c68ece6f048a225d82a7cb85.css">
-    <!--<![endif]-->
-    <!--[if IE 8]>
-      <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-ie8-d972b1b89dd1d4ce4766d283792aa800.css">
-    <![endif]-->
+      <!--<![endif]-->
+      <!--[if IE 8]>
+        <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-ie8-d972b1b89dd1d4ce4766d283792aa800.css">
+      <![endif]-->
   </head>
   <body class="govuk-template__body ">
     <header class="fb-block fb-block-header govuk-header" role="banner" data-module="header" data-block-id="config.header" data-block-type="header">
@@ -34,19 +34,19 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
-          <p class="govuk-body">Try again later.</p>
-          <p class="govuk-body">
-            Any answers you provided may not have been saved. When the service is available, you might have to start again.
-          </p>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body">
+              Any answers you provided may not have been saved. When the service is available, you might have to start again.
+            </p>
+          </div>
         </div>
-      </div>
       </main>
     </div>
 
-     <footer class="govuk-footer" role="contentinfo">
+    <footer class="govuk-footer" role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
@@ -59,26 +59,26 @@
               viewbox="0 0 483.2 195.7"
               height="17"
               width="41"
-            >
+              >
               <path
                 fill="currentColor"
                 d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-              />
+                />
             </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a
-                class="govuk-footer__link"
-                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                rel="license"
-              >Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
+              <span class="govuk-footer__licence-description">
+                All content is available under the
+                <a
+                  class="govuk-footer__link"
+                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                  rel="license"
+                  >Open Government Licence v3.0</a>, except where otherwise stated
+              </span>
           </div>
           <div class="govuk-footer__meta-item copyright">
             <a
               class="govuk-footer__link govuk-footer__copyright-logo"
               href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-            >© Crown copyright</a>
+              >© Crown copyright</a>
           </div>
         </div>
       </div>

--- a/rootfs/www/4xx.html
+++ b/rootfs/www/4xx.html
@@ -46,6 +46,8 @@
       </main>
     </div>
 
+    <hr />
+
     <footer class="govuk-footer" role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">

--- a/rootfs/www/5xx.html
+++ b/rootfs/www/5xx.html
@@ -6,13 +6,50 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        color: #0b0c0c;
+        margin: 20px 10%;
+      }
 
-    <!--[if !IE 8]><!-->
-      <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-12834c68c68ece6f048a225d82a7cb85.css">
-      <!--<![endif]-->
-      <!--[if IE 8]>
-        <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-ie8-d972b1b89dd1d4ce4766d283792aa800.css">
-      <![endif]-->
+      .govuk-header__container {
+        position: relative;
+        margin-bottom: -15px;
+        padding-top: 10px;
+        border-bottom: 10px solid #1d70b8;
+      }
+
+      .govuk-header {
+        background-color: black;
+        padding: 5px 10px;
+        margin-bottom: 50px;
+      }
+      .govuk-header a {
+        color: white;
+        text-decoration: none;
+        font-size: 30px;
+      }
+
+      .govuk-header__logotype {
+      }
+
+
+      .govuk-grid-row {
+        margin-bottom: 100px;
+      }
+
+      hr {
+        margin-top: 50px;
+        margin-bottom: 50px;
+      }
+
+      .govuk-footer
+        .govuk-footer__link {
+        color: #0b0c0c;
+      }
+
+    </style>
   </head>
   <body class="govuk-template__body ">
     <header class="fb-block fb-block-header govuk-header" role="banner" data-module="header" data-block-id="config.header" data-block-type="header">

--- a/rootfs/www/5xx.html
+++ b/rootfs/www/5xx.html
@@ -9,10 +9,10 @@
 
     <!--[if !IE 8]><!-->
       <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-12834c68c68ece6f048a225d82a7cb85.css">
-    <!--<![endif]-->
-    <!--[if IE 8]>
-      <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-ie8-d972b1b89dd1d4ce4766d283792aa800.css">
-    <![endif]-->
+      <!--<![endif]-->
+      <!--[if IE 8]>
+        <link rel="stylesheet" href="https://design-system.service.gov.uk/stylesheets/main-ie8-d972b1b89dd1d4ce4766d283792aa800.css">
+      <![endif]-->
   </head>
   <body class="govuk-template__body ">
     <header class="fb-block fb-block-header govuk-header" role="banner" data-module="header" data-block-id="config.header" data-block-type="header">
@@ -34,19 +34,19 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
-          <p class="govuk-body">Try again later.</p>
-          <p class="govuk-body">
-            Any answers you provided may not have been saved. When the service is available, you might have to start again.
-          </p>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body">
+              Any answers you provided may not have been saved. When the service is available, you might have to start again.
+            </p>
+          </div>
         </div>
-      </div>
       </main>
     </div>
 
-     <footer class="govuk-footer" role="contentinfo">
+    <footer class="govuk-footer" role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
@@ -59,26 +59,26 @@
               viewbox="0 0 483.2 195.7"
               height="17"
               width="41"
-            >
+              >
               <path
                 fill="currentColor"
                 d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-              />
+                />
             </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a
-                class="govuk-footer__link"
-                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                rel="license"
-              >Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
+              <span class="govuk-footer__licence-description">
+                All content is available under the
+                <a
+                  class="govuk-footer__link"
+                  href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                  rel="license"
+                  >Open Government Licence v3.0</a>, except where otherwise stated
+              </span>
           </div>
           <div class="govuk-footer__meta-item copyright">
             <a
               class="govuk-footer__link govuk-footer__copyright-logo"
               href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-            >© Crown copyright</a>
+              >© Crown copyright</a>
           </div>
         </div>
       </div>

--- a/rootfs/www/5xx.html
+++ b/rootfs/www/5xx.html
@@ -46,6 +46,8 @@
       </main>
     </div>
 
+    <hr />
+
     <footer class="govuk-footer" role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">


### PR DESCRIPTION
This makes the error pages look closer to gov.uk styling
but without pulling in any external CSS/font files.

This is as much as I can do in a reasonable amount of
time. If possible, it would be worth getting a
front-end developer to spend a bit of time improving
this.