### PR TITLE
Remove metrics endpoint for defaultBackend

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,8 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -70,8 +68,6 @@ func main() {
 	}
 
 	http.HandleFunc("/", errorHandler(errFilesPath))
-
-	http.Handle("/metrics", promhttp.Handler())
 
 	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := cloud-platform-custom-error-pages:0.4
+IMAGE := cloud-platform-custom-error-pages:0.5
 
 all: .built-image
 


### PR DESCRIPTION
As metrics from the Custom Error Page is not used and important.
This will fix the concern raised by security.