### PR TITLE
fix: 🐛 out of index range

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func errorHandler(path string) func(http.ResponseWriter, *http.Request) {
 		if err != nil {
 			log.Printf("unexpected error reading media type extension: %v. Using %v", err, ext)
 			format = "text/html"
-		} else if len(cext) == 1 {
+		} else if len(cext) <= 1 {
 			log.Printf("couldn't get media type extension. Using %v", ext)
 		} else {
 			ext = cext[1]


### PR DESCRIPTION
https://kibana.cloud-platform.service.justice.gov.uk/_plugin/kibana/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(columns:!(_source),filters:!(),index:'8a728bc0-00eb-11ec-9062-27aa363b66a2',interval:auto,query:(language:kuery,query:'%22runtime%20error:%20index%20out%20of%20range%20%5B1%5D%20with%20length%200%22'),sort:!())