### PR TITLE
remove misleading text for default-backend 5xx custom error page

### DIFF
--- a/rootfs/www/5xx.html
+++ b/rootfs/www/5xx.html
@@ -72,16 +72,13 @@
         </div>
       </div>
     </header>
-    
+
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
             <p class="govuk-body">Try again later.</p>
-            <p class="govuk-body">
-              Any answers you provided may not have been saved. When the service is available, you might have to start again.
-            </p>
           </div>
         </div>
       </main>


### PR DESCRIPTION
As per ticket https://github.com/orgs/ministryofjustice/projects/65/views/3?pane=issue&itemId=76571520 

remove the text from file https://github.com/ministryofjustice/cloud-platform-custom-error-pages/blob/3994142dca6863529d5a243b5b584bea4b9f5a94/rootfs/www/5xx.html#L83
which refers to saved answers from the 500 error used by CP namespaces, as it is not applicable for all services.

