### PR TITLE
chore: 🤖 bump go version to 1.25.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2-alpine3.19 AS builder
+FROM golang:1.25.2-alpine3.22 AS builder
 
 RUN addgroup -g 1000 -S appgroup && \
   adduser -u 1000 -S appuser -G appgroup

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ defaultBackend:
   port: 8080
 ```
 
+## Cutting a new release
+
+Upon applying updates to this repo and or Dockerfile, create a new release. This will trigger a GitHub action to build and push a new image to Docker Hub with the tag matching the release version.
+
+You'll also need to update the image tag ref in `run.sh` to match the new version.
+
 [instructions]: https://github.com/kubernetes/ingress-nginx/tree/master/docs/examples/customization/custom-errors
 [example]: https://github.com/kubernetes/ingress-nginx/tree/master/images/custom-error-pages
 [infrastructure-repo]: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/nginx-ingress-acme.tf

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ministryofjustice/cloud-platform-custom-error-pages
 
-go 1.22.1
+go 1.25
 
 require github.com/prometheus/client_golang v1.19.0
 

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE=ministryofjustice/cloud-platform-custom-error-pages:1.1.4
+IMAGE=ministryofjustice/cloud-platform-custom-error-pages:1.1.6
 
 docker run --rm \
   --name errorpage \


### PR DESCRIPTION
update go version refs, run.sh and readme for release guidance

relates to https://github.com/ministryofjustice/cloud-platform-security-issues/issues/125